### PR TITLE
Fix balance queries and datastore expiry

### DIFF
--- a/src/Account.php
+++ b/src/Account.php
@@ -190,7 +190,7 @@ class Account
         $stmt = $this->db->prepare($query);
         $stmt = DatabaseHelpers::filterBind($stmt, 'address', $address, DatabaseHelpers::ALPHA_NUMERIC, 40);
         $stmt->execute();
-        $unspentTransactions = $stmt->fetch(PDO::FETCH_ASSOC) ?: [];
+        $unspentTransactions = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
 
         foreach ($unspentTransactions as $unspentTransaction) {
             $balance = bcadd($balance, $unspentTransaction['value']);
@@ -213,7 +213,7 @@ class Account
         $stmt = $this->db->prepare($query);
         $stmt = DatabaseHelpers::filterBind($stmt, 'address', $address, DatabaseHelpers::ALPHA_NUMERIC, 40);
         $stmt->execute();
-        $transactions = $stmt->fetch(PDO::FETCH_ASSOC) ?: [];
+        $transactions = $stmt->fetchAll(PDO::FETCH_ASSOC) ?: [];
 
         foreach ($transactions as $transaction) {
             $key = $transaction['transaction_id'] . '-' . $transaction['tx_id'];

--- a/src/DataStore.php
+++ b/src/DataStore.php
@@ -44,20 +44,16 @@ class DataStore
         $stmt = DatabaseHelpers::filterBind($stmt, 'key', $key, DatabaseHelpers::TEXT);
         $stmt->execute();
 
-        $retVal = null;
+        $retVal = $default;
         $record = $stmt->fetch(PDO::FETCH_ASSOC) ?: null;
 
         if ($record !== null) {
             $expires = $record['expires'];
 
-            if ($expires === 0) {
-                $retVal = $record['data'];
-            } elseif (time() < $expires) {
+            if ($expires === 0 || time() < $expires) {
                 $retVal = $record['data'];
             }
 
-        } else {
-            $retVal = $default;
         }
 
         return $retVal;


### PR DESCRIPTION
## Summary
- fix fetching lists of transactions from DB
- return default for expired keys in datastore

## Testing
- `composer test` *(fails: composer not found)*

------
https://chatgpt.com/codex/tasks/task_e_685da021c770832ab65e991f1840b110